### PR TITLE
Retry fetching device list from server

### DIFF
--- a/terraware_devices/device_manager.py
+++ b/terraware_devices/device_manager.py
@@ -105,8 +105,7 @@ class DeviceManager(object):
                 device_infos = r.json()['devices']
             except Exception as ex:
                 print('error requesting devices from server %s: %s' % (server_name, ex))
-
-            time.sleep(10)
+                gevent.sleep(10)
 
         count_added = self.create_devices(device_infos)
         print('loaded %d devices from %s' % (count_added, server_name))


### PR DESCRIPTION
Currently, if the device manager fails to fetch the device list from the server
during initialization, one of two things happens.

If the server is completely down (say, because it's restarting) the requests
library raises an exception. The exception bubbles up to the top level and gets
logged with a stack trace. The device manager exits. Balena restarts it right
away, resulting in a lot of log noise.

If the server is up but returns an HTTP error, an error message is logged but
not treated as fatal. That effectively causes the device manager to sleep forever
since it has no devices to poll.

Change the code so it logs a brief error message for any kind of failure and
retries fetching the device list 10 seconds later.

CU-r14ywq
